### PR TITLE
BUG : return DHT_ERROR_CHECKSUM when temperature is negative.

### DIFF
--- a/DHT22.cpp
+++ b/DHT22.cpp
@@ -205,8 +205,8 @@ DHT22_ERROR_t DHT22::readData()
   if(currentTemperature & 0x8000)
   {
    // Below zero, non standard way of encoding negative numbers!
-    currentTemperature &= 0x7FFF;
-    _lastTemperature = (float(currentTemperature) / 10.0) * -1.0;
+   //currentTemperature &= 0x7FFF; -> if we modify currentTemperature after computing checksum, ERROR_CHECKSUM is returned
+    _lastTemperature = (float(currentTemperature & 0x7FFF) / 10.0) * -1.0;
   }
   else
   {


### PR DESCRIPTION
So I removed "currentTemperature &= 0x7FFF" line 208 and put "& 0x7FFF" in the expression line 209.
Now it works with negative temperatures.
